### PR TITLE
Add warlock's Call Observer spell

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -88,6 +88,7 @@ if APILevel >= 8 then
 
         -- Warlock
         [179193] = { 353601, 15 }, -- Fel Obelisk
+        [107100] = { 201996, 20 }, -- Call Observer
     }
 elseif APILevel == 3 then
     totemNpcIDs = {


### PR DESCRIPTION
This pull request adds an icon for the observer summoned by Warlock's Call Observer PvP talent:

![image](https://github.com/rgd87/NugTotemIcon/assets/2417276/fc9e71de-268c-4b7b-ba47-8fbd214dd713)
